### PR TITLE
Image custom component and Post title/date

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^18.2.0",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.1.2",
     "react-fontawesome": "^1.7.1",
     "react-scripts": "5.0.1",
     "react-syntax-highlighter": "^15.5.0",

--- a/src/App.css
+++ b/src/App.css
@@ -44,6 +44,28 @@ button.icon {
   align-items: center;
   height: 100%;
 }
+.title-container {
+  max-width: 50rem;
+  margin: 0 auto;
+  padding: 0.5rem 0.5rem 0 0.5rem;
+  cursor: pointer;
+}
+
+.post-title {
+  font-size: 2.5rem;
+  font-family: Georgia, 'Times New Roman', Times, serif;
+  font-weight: 200;
+  margin-bottom: 5px;
+}
+.post-subtitle {
+  font-size: medium;
+  margin-top: 0;
+  opacity: 0.6;
+  transition: all 0.3s ease-in-out;
+}
+.post-subtitle:hover {
+  opacity: 0.8;
+}
 
 /* Header */
 .header {

--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,7 @@ function App() {
 
       <div className="body-wrapper">
         {
-          blogData.map((blog, key) => (
+          blogData.sort((a, b) => new Date(b.date) - new Date(a.date)).map((blog, key) => (
             <Post key={key} contentPath={blog.url} title={blog.title} date={blog.date}></Post>
           ))
         }

--- a/src/App.js
+++ b/src/App.js
@@ -25,7 +25,7 @@ function App() {
       <div className="body-wrapper">
         {
           blogData.map((blog, key) => (
-            <Post key={key} contentPath={blog.url}></Post>
+            <Post key={key} contentPath={blog.url} title={blog.title} date={blog.date}></Post>
           ))
         }
       </div>

--- a/src/components/Code.jsx
+++ b/src/components/Code.jsx
@@ -11,6 +11,9 @@ import java from 'react-syntax-highlighter/dist/esm/languages/prism/java';
 import yaml from 'react-syntax-highlighter/dist/esm/languages/prism/yaml';
 import json from 'react-syntax-highlighter/dist/esm/languages/prism/json';
 
+// For handling errors in syntax highlighting
+import { ErrorBoundary } from 'react-error-boundary';
+
 SyntaxHighlighter.registerLanguage('python', python);
 SyntaxHighlighter.registerLanguage('java', java);
 SyntaxHighlighter.registerLanguage('yaml', yaml);
@@ -26,6 +29,14 @@ const Code = ({ children, language }) => {
     return () => clearTimeout(timer)
   }, [copied])
 
+  function errorCode(error){
+    return (
+      <div className='error-code-block-wrapper'>
+        <p className='error-code-block'>Error: {error}</p>
+      </div>
+    )
+  }
+
   return (
     <div className="code">
       <CopyToClipboard text={children} onCopy={() => setCopied(true)}>
@@ -33,13 +44,16 @@ const Code = ({ children, language }) => {
           {copied ? <FontAwesomeIcon icon={faCheck} /> : <FontAwesomeIcon icon={faClone} />}
         </button>
       </CopyToClipboard>
-      <SyntaxHighlighter
-        language={language}
-        style={oneDark}
-        customStyle={{borderRadius: "10px"}}
-      >
-        {children}
-      </SyntaxHighlighter>
+      <ErrorBoundary
+        fallbackRender={errorCode}>
+        <SyntaxHighlighter
+          language={language}
+          style={oneDark}
+          customStyle={{borderRadius: "10px"}}
+        >
+          {children}
+        </SyntaxHighlighter>
+      </ErrorBoundary>
     </div>
   )
 }

--- a/src/components/Image.jsx
+++ b/src/components/Image.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
-const Image = ({src, alt, styles}) => {
+const Image = ({src, alt, style}) => {
   return (
     // STYLE prop instead of style because that allows me to pass in CSS as string
-    <img src={src} alt={alt} STYLE={styles}/>
+    <img src={src} alt={alt} style={style}/>
   )
 }
 

--- a/src/components/Image.jsx
+++ b/src/components/Image.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+const Image = ({src, alt, styles}) => {
+  return (
+    // STYLE prop instead of style because that allows me to pass in CSS as string
+    <img src={src} alt={alt} STYLE={styles}/>
+  )
+}
+
+export default Image

--- a/src/components/Post.jsx
+++ b/src/components/Post.jsx
@@ -5,7 +5,7 @@ import InlineCode from "./InlineCode";
 import Strikethrough from "./Strikethrough";
 import Blockquote from "./Blockquote";
 
-const Post = ( {contentPath} ) => {
+const Post = ( {contentPath, title, date} ) => {
   const [postContent, setPostContent] = useState("");
 
   useEffect(() => {
@@ -17,6 +17,10 @@ const Post = ( {contentPath} ) => {
 
   return (
     <article className="article">
+      <div className="title-container">
+        <h1 className="post-title">{title}</h1>
+        <h3 className="post-subtitle">{date}</h3>
+      </div>
       <div className="container">
         <div className="post-wrapper">
           <Markdown options={{

--- a/src/components/Post.jsx
+++ b/src/components/Post.jsx
@@ -1,6 +1,7 @@
 import Markdown from "markdown-to-jsx"
 import { useEffect, useState } from "react"
 import Code from "./Code";
+import Image from "./Image";
 import InlineCode from "./InlineCode";
 import Strikethrough from "./Strikethrough";
 import Blockquote from "./Blockquote";
@@ -36,6 +37,9 @@ const Post = ( {contentPath, title, date} ) => {
               },
               blockquote: {
                 component: Blockquote
+              },
+              Image: {
+                component: Image
               }
             }
           }}>


### PR DESCRIPTION
Added custom `<Image>` component. This component allows to pass in a `src`, `alt` and `styles` from the markdown file.

Blog posts now each have a `title` and `date` displayed in large text above, so multiple blogs can be differentiated